### PR TITLE
Add rule suggesting static immutable property

### DIFF
--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -106,7 +106,7 @@ public let builtInRules: [Rule.Type] = [
     LegacyRandomRule.self,
     LetVarWhitespaceRule.self,
     LineLengthRule.self,
-    LiteralExpressionEndIdentationRule.self,
+    LiteralExpressionEndIndentationRule.self,
     LocalDocCommentRule.self,
     LowerACLThanParentRule.self,
     MarkRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyRandomRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyRandomRule.swift
@@ -14,9 +14,9 @@ struct LegacyRandomRule: SwiftSyntaxRule, ConfigurationProviderRule {
             Example("Float.random(in: 0 ..< 1)\n")
         ],
         triggeringExamples: [
-            Example("↓arc4random(10)\n"),
+            Example("↓arc4random()\n"),
             Example("↓arc4random_uniform(83)\n"),
-            Example("↓drand48(52)\n")
+            Example("↓drand48()\n")
         ]
     )
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/LiteralExpressionEndIndentationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/LiteralExpressionEndIndentationRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
-struct LiteralExpressionEndIdentationRule: Rule, ConfigurationProviderRule, OptInRule {
+struct LiteralExpressionEndIndentationRule: Rule, ConfigurationProviderRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -141,7 +141,7 @@ struct LiteralExpressionEndIdentationRule: Rule, ConfigurationProviderRule, OptI
     fileprivate static let notWhitespace = regex("[^\\s]")
 }
 
-extension LiteralExpressionEndIdentationRule: CorrectableRule {
+extension LiteralExpressionEndIndentationRule: CorrectableRule {
     func correct(file: SwiftLintFile) -> [Correction] {
         let allViolations = violations(in: file).reversed().filter { violation in
             guard let nsRange = file.stringView.byteRangeToNSRange(violation.range) else {
@@ -206,7 +206,7 @@ extension LiteralExpressionEndIdentationRule: CorrectableRule {
     }
 }
 
-extension LiteralExpressionEndIdentationRule {
+extension LiteralExpressionEndIndentationRule {
     fileprivate struct Violation {
         var indentationRanges: (expected: NSRange, actual: NSRange)
         var endOffset: ByteCount

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -626,9 +626,9 @@ class LineLengthRuleGeneratedTests: SwiftLintTestCase {
     }
 }
 
-class LiteralExpressionEndIdentationRuleGeneratedTests: SwiftLintTestCase {
+class LiteralExpressionEndIndentationRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
-        verifyRule(LiteralExpressionEndIdentationRule.description)
+        verifyRule(LiteralExpressionEndIndentationRule.description)
     }
 }
 


### PR DESCRIPTION
Adds a rule that suggests to use  a static modifier for immutable initialized properties.

So this:

```
struct Foo {
   let property = 2
}
```

is suggested to be: 


```
struct Foo {
   static let property = 2
}
```

